### PR TITLE
Adds package est with first function FileExists

### DIFF
--- a/est/file_exists.go
+++ b/est/file_exists.go
@@ -1,0 +1,17 @@
+package est
+
+import (
+	"fmt"
+	"os"
+)
+
+func FileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("could not stat file: %s", err)
+	}
+	return true, nil
+}

--- a/est/file_exists_test.go
+++ b/est/file_exists_test.go
@@ -1,0 +1,76 @@
+package est_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudfoundry/packit/est"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testFileExists(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect   = NewWithT(t).Expect
+		tempDir  string
+		tempFile string
+	)
+
+	it.Before(func() {
+		var err error
+		tempDir, err = ioutil.TempDir("", "some-dir")
+		Expect(err).ToNot(HaveOccurred())
+
+		tempFile = filepath.Join(tempDir, "some-file")
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(tempDir)).To(Succeed())
+	})
+
+	context("FileExists", func() {
+		context("when the file exists", func() {
+			it.Before(func() {
+				Expect(ioutil.WriteFile(tempFile, []byte(`some contents`), 0644)).To(Succeed())
+			})
+			it("return true", func() {
+				exists, err := est.FileExists(tempFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(exists).To(BeTrue())
+			})
+		})
+
+		context("file does not exist", func() {
+			it("returns false", func() {
+				exists, err := est.FileExists(tempFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(exists).To(BeFalse())
+			})
+		})
+
+		context("failure cases", func() {
+
+			context("it can not read, write, or execute inside dir where file is", func() {
+				it.Before(func() {
+					Expect(ioutil.WriteFile(tempFile, []byte(`some contents`), 0644)).To(Succeed())
+					Expect(os.Chmod(tempDir, 0000)).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Chmod(tempDir, os.ModePerm)).To(Succeed())
+				})
+
+				it("returns false", func() {
+					_, err := est.FileExists(tempFile)
+					Expect(err).To(MatchError(ContainSubstring("could not stat file:")))
+					Expect(err).To(MatchError(ContainSubstring("permission denied")))
+				})
+			})
+		})
+	})
+}

--- a/est/init_test.go
+++ b/est/init_test.go
@@ -1,0 +1,14 @@
+package est_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestUnitPackit(t *testing.T) {
+	suite := spec.New("Est", spec.Report(report.Terminal{}))
+	suite("FileExists", testFileExists)
+	suite.Run(t)
+}


### PR DESCRIPTION
I have created a package called `est` that I would like to contain functions that help with verifying the state of files. To start I have added a FileExists function that checks to see whether or not a given file exist. I think that this would be a good place to also add functions like checking for symlinks, seeing it a file is executable or not, et cetera.